### PR TITLE
Add an option to add a salt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,6 +35,14 @@ module.exports = function(grunt) {
         src: '**',
         dest: 'tmp/default'
       },
+      salt: {
+        options: {
+          salt: 'cachebuster5000'
+        },
+        cwd: 'test/assets',
+        src: '**',
+        dest: 'tmp/salt'
+      },
       etag: {
         options: {
           etag: true,
@@ -70,7 +78,7 @@ module.exports = function(grunt) {
         // Include these in a non-sorted order, so we can verify the output is sorted
         src: ['blank.gif', 'mod/*', 'a.js', 'hash.json', 'a.css'],
         dest: 'tmp/sorted'
-      },
+      }
     },
 
     // Unit tests.

--- a/tasks/hashmap.js
+++ b/tasks/hashmap.js
@@ -29,6 +29,7 @@ module.exports = function(grunt) {
       rename: defaultRename, // save the original file as what
       keep: true, // should we keep the original file or not
       hashlen: 10, // length for hashsum digest
+      salt: null   // salt to add to the file contents before hashing
     });
 
     grunt.template.addDelimiters('#{ }', '#{', '}');
@@ -93,6 +94,9 @@ module.exports = function(grunt) {
             shasum.update(data);
           });
           s.on('end', function() {
+            if (options.salt) {
+              shasum.update(options.salt);
+            }
             d = shasum.digest('hex').slice(0, options.hashlen);
             stash(filepath, d);
           });

--- a/test/hashmap_test.js
+++ b/test/hashmap_test.js
@@ -45,6 +45,16 @@ exports.hashmap = {
 
     test.done();
   },
+  salt: function(test) {
+    test.expect(1);
+
+    var result1 = grunt.file.readJSON('tmp/default/hash.json');
+    var result2 = grunt.file.readJSON('tmp/salt/hash.json');
+
+    test.ok(result1['a.js'] !== result2['a.js'], 'Added salt changes hash.');
+
+    test.done();
+  },
   etag: function(test) {
     test.expect(1);
 


### PR DESCRIPTION
Sometimes it's necessary to bust the cache for all your files.
This may happen if you have a configuration issue and are deploying to a CDN.

This pull request just allows you to add a salt to all files before hashing, which allows you to bust the cache for all files.
