### PR TITLE
Normalize path to match platform

### DIFF
--- a/tasks/hashmap.js
+++ b/tasks/hashmap.js
@@ -142,7 +142,7 @@ module.exports = function(grunt) {
         var srcfile = realpath(filepath);
         var destfile = path.join(dest, renamed(filepath));
         if (srcfile !== destfile) {
-          if (destfile.indexOf(dest) === -1) {
+          if (destfile.indexOf(path.normalize(dest)) === -1) {
             grunt.log.warn('Renamed target "' + destfile + '" is not in dest directory.');
           }
           grunt.file.copy(srcfile, destfile);


### PR DESCRIPTION
The warning about the renamed target not existing in the destination
directory was incorrectly being shown on Windows if the dest path used
forward slashes. This was due to a comparison against a Windows-style
path with back slashes. To correctly handle this, we just normalize the
destination path before comparing it to a computed path.

Fixes https://github.com/ktmud/grunt-hashmap/issues/8